### PR TITLE
Fix for title casing an undefined string

### DIFF
--- a/app/src/helpers/libs.js
+++ b/app/src/helpers/libs.js
@@ -105,10 +105,13 @@ export function titleCase(str) {
     if (str.length == 0) return str;
     return str[0].toUpperCase() + str.slice(1);
   }
-  // If the input string is ALL CAPS, lowercase it first so capitalize() can actually
-  // Title Case the string
-  const returnStr =
-    str === str.toUpperCase() ? str.toLowerCase().split(" ") : str.split(" ");
+  // If the input string is undefined, return an empty string, if the input string is
+  // ALL CAPS, lowercase it first so capitalize() can actually Title Case the string
+  const returnStr = !str
+    ? []
+    : str === str.toUpperCase()
+    ? str.toLowerCase().split(" ")
+    : str.split(" ");
 
   return returnStr.map(capitalize).join(" ");
 }

--- a/app/src/helpers/logger.js
+++ b/app/src/helpers/logger.js
@@ -40,6 +40,7 @@ export async function logMessage(logData, severity) {
             userAgent: window.navigator.userAgent,
             appVersion: version,
           };
+          console.log(JSON.stringify({ ...data, ...{ additionalData } }));
           return JSON.stringify({ ...data, ...additionalData });
         },
       ],
@@ -64,7 +65,7 @@ export async function logMessage(logData, severity) {
       },
     };
 
-    let apiEndpoint = severity === "error" ? "/error" : "/info";
+    let apiEndpoint = severity.toLowerCase() === "error" ? "/error" : "/info";
 
     try {
       axios.create(axiosConfig).post(apiEndpoint, logData);

--- a/app/src/manufacturers/chevrolet.js
+++ b/app/src/manufacturers/chevrolet.js
@@ -77,7 +77,7 @@ function formatChevroletInventoryResults(input) {
     // bring some nested values up to the top level and create entries that don't exist
     const enhancedResult = {
       ...vehicle,
-      dealerName: titleCase(vehicle.dealer?.name),
+      dealerName: titleCase(vehicle?.dealer?.name),
       dealerDistance: vehicle.dealer?.distance,
       trimName: vehicle.trim?.name,
       totalPrice: vehicle.pricing?.cash?.summary?.items

--- a/app/tests/libs.test.js
+++ b/app/tests/libs.test.js
@@ -18,6 +18,10 @@ describe("Helper Tests", () => {
   });
 });
 
+test("Title case for an undefined string should return an empty string", () => {
+  expect(libs.titleCase(undefined)).toBe("");
+});
+
 test("Number should be converted to currency", () => {
   expect(libs.convertToCurrency(38091)).toBe("$38,091");
   expect(libs.convertToCurrency(147062)).toBe("$147,062");


### PR DESCRIPTION
A call to `titleCase(string)` where `string` was undefined would result in an `Cannot read properties of undefined (reading 'toUpperCase')` error, preventing the Inventory Table from populating.

Fixes #91 